### PR TITLE
Only define _GNU_SOURCE if not already set

### DIFF
--- a/linux_scsi.c
+++ b/linux_scsi.c
@@ -16,9 +16,10 @@
 */
 #include "dbench.h"
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <stdio.h>
-#undef _GNU_SOURCE
 
 #include <fcntl.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
Signed-off-by: Ronnie Sahlberg <ronniesahlberg@gmail.com>